### PR TITLE
Tab bar: hide avatar when there's only one account

### DIFF
--- a/DireFloof/DWTabBarController.m
+++ b/DireFloof/DWTabBarController.m
@@ -202,7 +202,12 @@ typedef NS_ENUM(NSUInteger, DWTabItem) {
         [self.centerTabOverlay autoAlignAxis:ALAxisVertical toSameAxisOfView:self.tabBar];
         [self.centerTabOverlay autoAlignAxis:ALAxisHorizontal toSameAxisOfView:self.tabBar];
     }
-    
+
+    // We don't need the avatar icon, user already knows what account is being used
+    if ([[[MSAppStore sharedStore] availableInstances] count] == 1) {
+        return;
+    }
+
     if (!self.avatarImageView) {
         UIView *menuOverlay = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 21.0f, 21.0f)];
         menuOverlay.clipsToBounds = YES;


### PR DESCRIPTION
The avatar as a reminder of what account is being used is unnecessary if the user only has one account!

This is a really minor change but was something that vaguely bugged me.