### PR TITLE
About: fix scrolling to top of text

### DIFF
--- a/DireFloof/DWAboutViewController.m
+++ b/DireFloof/DWAboutViewController.m
@@ -73,6 +73,10 @@
 }
 
 
+- (void)viewDidLayoutSubviews {
+    [self.textView setContentOffset:CGPointZero animated:NO];
+}
+
 - (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.


### PR DESCRIPTION
On devices with smaller screens, like the iPhone SE, the entire About text doesn't fit on screen at once. When the text is added to the textView, the scroll is at the bottom - not the top. Unfortunately we have to manually scroll to the top. :(

Before:

<img width="432" alt="screen shot 2017-05-05 at 8 14 02 pm" src="https://cloud.githubusercontent.com/assets/780485/25769516/4a3ea5be-31d0-11e7-83d1-346c52d7c75b.png">

After:

<img width="432" alt="screen shot 2017-05-05 at 8 14 04 pm" src="https://cloud.githubusercontent.com/assets/780485/25769517/4d93e7a6-31d0-11e7-8052-b03dcf38b50b.png">
