### PR TITLE
Use 'search' API instead of 'accounts/search'

### DIFF
--- a/DireFloof/MSUserStore.m
+++ b/DireFloof/MSUserStore.m
@@ -236,14 +236,18 @@
 {
     NSDictionary *params = @{@"q":query, @"limit":@(5)};
     
-    [[MSAPIClient sharedClientWithBaseAPI:[[MSAppStore sharedStore] base_api_url_string]] GET:@"accounts/search" parameters:params progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+    [[MSAPIClient sharedClientWithBaseAPI:[[MSAppStore sharedStore] base_api_url_string]] GET:@"search" parameters:params progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
         
         NSMutableArray *accounts = [@[] mutableCopy];
-        
-        for (NSDictionary *accountJSON in responseObject) {
-            MSAccount *account = [[MSAccount alloc] initWithParams:accountJSON];
+
+        id responseAccounts = [responseObject objectForKey:@"accounts"];
+
+        if (responseAccounts != nil) {
+            for (NSDictionary *accountJSON in responseAccounts) {
+                MSAccount *account = [[MSAccount alloc] initWithParams:accountJSON];
             
-            [accounts addObject:account];
+                [accounts addObject:account];
+            }
         }
         
         if (completion != nil) {

--- a/DireFloof/MSUserStore.m
+++ b/DireFloof/MSUserStore.m
@@ -234,7 +234,7 @@
 
 - (void)searchForUsersWithQuery:(NSString *)query withCompletion:(void (^)(BOOL, NSArray *, NSError *))completion
 {
-    NSDictionary *params = @{@"q":query, @"limit":@(5)};
+    NSDictionary *params = @{@"q":query, @"resolve":@"true"};
     
     [[MSAPIClient sharedClientWithBaseAPI:[[MSAppStore sharedStore] base_api_url_string]] GET:@"search" parameters:params progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
         


### PR DESCRIPTION
This is one thing I was missing - the ability to search for accounts by their URL, e.g. ```https://mastodon.social/@WebComics``` as it's possible in the Mastodon's web app. This is handy because in some situation it is easier to just copy the URL then selecting and copying the user name.
The change is very lite: just use the ['search' API](https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#search) instead of 'account/search'.