### PR TITLE
Percent-encode slashes when translating statuses

### DIFF
--- a/DireFloof/DWTimelineTableViewCell.m
+++ b/DireFloof/DWTimelineTableViewCell.m
@@ -151,7 +151,10 @@
         
         MSStatus *status = self.status.reblog ? self.status.reblog : self.status;
         
-        NSString *encodedStatus = [status.content stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+        NSMutableCharacterSet *allowedCharacters = [[NSCharacterSet URLPathAllowedCharacterSet] mutableCopy];
+        [allowedCharacters removeCharactersInString:@"/"];
+
+        NSString *encodedStatus = [status.content stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
         NSString *url = [NSString stringWithFormat:@"https://translate.google.com/#auto/auto/%@", encodedStatus];
         
         [self.delegate timelineCell:self didSelectURL:[NSURL URLWithString:url]];


### PR DESCRIPTION
I have noticed that when a toot contains a slash character, translation gets cut starting from the slash.
Looks like the correct way to encode content for translation should be "allow all the characters that are usually allowed in the `path` part of URL, excluding the slash character".