### PR TITLE
Closes #41: Use NSDataDetector to detect links, which handles non-ascii characters

### DIFF
--- a/DireFloof/DWTimelineTableViewCell.m
+++ b/DireFloof/DWTimelineTableViewCell.m
@@ -509,14 +509,13 @@
 
 - (void)highlightUsersInContentLabel:(TTTAttributedLabel *)attributedLabel forStatus:(MSStatus *)status
 {
-    NSArray *URLs = [TwitterText URLsInText:status.content];
+    NSDataDetector *detector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink error:nil];
+    NSArray<NSTextCheckingResult *> *URLs = [detector matchesInString:status.content options:0 range:NSMakeRange(0, status.content.length)];
     NSArray *mentions = [TwitterText mentionedScreenNamesInText:status.content];
     NSArray *hashtags = [TwitterText hashtagsInText:status.content checkingURLOverlap:YES];
     
-    for (TwitterTextEntity *entity in URLs) {
-        
-        NSURL *url = [NSURL URLWithString:[status.content substringWithRange:entity.range]];
-        [attributedLabel addLinkToURL:url withRange:entity.range];
+    for (NSTextCheckingResult *result in URLs) {
+        [attributedLabel addLinkToURL:result.URL withRange:result.range];
     }
     
     for (TwitterTextEntity *entity in mentions) {


### PR DESCRIPTION
`twitter-text` does not handle non-ascii characters in its URL matching (see https://github.com/twitter/twitter-text/issues/36)

This change switches to NSDataDetectors which should be much more permissive about URL formatting. One concern may be that this implementation is still not the same as the matching applied by the Mastodon web UI (see [url_regex.js](https://github.com/tootsuite/mastodon/blob/6db034a866b78e4e98b122461ca84763f0104381/app/javascript/mastodon/features/compose/util/url_regex.js)), which was based on the javascript implementation of twitter-text. I attempted to use some of the same regex rules but it quickly ballooned into a complicated mess. I think this solves the issue with the least pain.