### PR TITLE
Deep link changes.

### DIFF
--- a/DireFloof/MSStatusStore.m
+++ b/DireFloof/MSStatusStore.m
@@ -491,40 +491,6 @@ static CGFloat maxDimensions = 1024.0f;
 }
 
 
-- (void)searchStatusWithUrl:(NSString *)searchUrl withCompletion:(void (^)(BOOL, MSStatus *, NSError *))completion
-{
-    NSDictionary *params = @{@"q":searchUrl, @"resolve": @(true)};
-    
-    [[MSAPIClient sharedClientWithBaseAPI:[[MSAppStore sharedStore] base_api_url_string]] GET:@"search" parameters:params progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
-        
-        NSMutableArray *statuses = [@[] mutableCopy];
-        
-        if (responseObject != nil) {
-            NSDictionary *statusJSON = [[responseObject objectForKey:@"statuses"] firstObject];
-            
-            if (statusJSON != nil) {
-                MSStatus *status = [[MSStatus alloc] initWithParams:statusJSON];
-                
-                if (completion != nil) {
-                    completion(YES, status, nil);
-                }
-            }
-            else if (completion != nil)
-            {
-                completion(YES, nil, nil);
-            }
-        }
-        else if (completion != nil) {
-            completion(YES, nil, nil);
-        }
-    } failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
-        if (completion != nil) {
-            completion(NO, nil, error);
-        }
-    }];
-}
-
-
 - (void)updateProgressOnExportSession:(AVAssetExportSession *)exportSession
 {
     dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
This PR follows up on [this comment thread](https://github.com/ReticentJohn/Amaroq/commit/e1a8283c966b0a2bd07d5b028c15060a6be09db9#r32822898) to make the `status` deep link host more generic. The host has been renamed `open` (since it can open a variety of Mastodon entities), and is now capable of having either account or status URLs passed to it.

For example:
`amaroq://open?url=https%3A%2F%2Fmastodon.social%2F%40Gargron%2F101927228503810895` for a status.
`amaroq://open?url=https%3A%2F%2Ftoot.cafe%2F%40chartier` for an account.

Here's a video of this in action:
https://db.tt/i9LwxgtfIk