### PR TITLE
Fix typo in "Privacybeleid" in Dutch translation

### DIFF
--- a/DireFloof/DireFloof/nl.xliff
+++ b/DireFloof/DireFloof/nl.xliff
@@ -1317,7 +1317,7 @@ Amaroq is built and maintained by a love of the Mastodon idea, which sorely has 
       </trans-unit>
       <trans-unit id="rjX-Ma-KFp.normalTitle">
         <source>Privacy Policy</source>
-        <target>Pribacybeleid</target>
+        <target>Privacybeleid</target>
         <note>Class = "UIButton"; normalTitle = "Privacy Policy"; ObjectID = "rjX-Ma-KFp";</note>
       </trans-unit>
       <trans-unit id="s1z-SI-cBc.text">

--- a/DireFloof/nl.lproj/Main.strings
+++ b/DireFloof/nl.lproj/Main.strings
@@ -701,7 +701,7 @@
 "r1g-xo-uUC.text" = "0 •";
 
 /* Class = "UIButton"; normalTitle = "Privacy Policy"; ObjectID = "rjX-Ma-KFp"; */
-"rjX-Ma-KFp.normalTitle" = "Pribacybeleid";
+"rjX-Ma-KFp.normalTitle" = "Privacybeleid";
 
 /* Class = "UILabel"; text = "13 hours ago"; ObjectID = "s1z-SI-cBc"; */
 "s1z-SI-cBc.text" = "13 uur geleden";


### PR DESCRIPTION
The welcome screen contains a spelling mistake in the link to the privacy policy. It should be spelled `Privacybeleid`, and not `Pribacybeleid`.

The same word also appears elsewhere in the application (post-login) where it is correct already, without spelling mistake.

The typo was introduced in https://github.com/ReticentJohn/Amaroq/commit/15f519a41cd6891257826ea282b669d41dae0267.